### PR TITLE
feat(frontend/pages): Implement Leaderboard for user data display

### DIFF
--- a/frontend/src/pages/Leaderboard.js
+++ b/frontend/src/pages/Leaderboard.js
@@ -1,0 +1,23 @@
+import LeaderboardCard from "components/LeaderboardCard";
+import LeaderboardTable from "components/tables/LeaderboardTable";
+import useLeaderboard from "hooks/useLeaderboard";
+
+export default function Leaderboard() {
+  const user = useLeaderboard();
+
+  if (!user) {
+    return <h1>Loading...</h1>;
+  }
+
+  return (
+    <>
+      <div className="md:block hidden bg-light py-28">
+        <LeaderboardTable user={user} />
+      </div>
+
+      <div className="block md:hidden pt-8">
+        <LeaderboardCard user={user} />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Use the useLeaderboard hook to fetch user data from the API.
- Implement loading state to indicate when data is being fetched.
- Render user data conditionally:
- Use LeaderboardTable for larger screens.
- Use LeaderboardCard for smaller screens.