### PR TITLE
feat(frontend/data): build sample data to display statistics card

### DIFF
--- a/frontend/src/data/statistics-cards-data.js
+++ b/frontend/src/data/statistics-cards-data.js
@@ -1,0 +1,55 @@
+import {
+  faMoneyBillWave,
+  faUserPlus,
+  faUser,
+  faChartBar,
+} from "@fortawesome/free-solid-svg-icons";
+
+export const statisticsCardsData = [
+  {
+    color: "gray",
+    icon: faMoneyBillWave,
+    title: "Today's Money",
+    value: "$53k",
+    footer: {
+      color: "text-green-500",
+      value: "+55%",
+      label: "than last week",
+    },
+  },
+  {
+    color: "gray",
+    icon: faUser,
+    title: "Today's Users",
+    value: "2,300",
+    footer: {
+      color: "text-green-500",
+      value: "+3%",
+      label: "than last month",
+    },
+  },
+  {
+    color: "gray",
+    icon: faUserPlus,
+    title: "New Clients",
+    value: "3,462",
+    footer: {
+      color: "text-red-500",
+      value: "-2%",
+      label: "than yesterday",
+    },
+  },
+  {
+    color: "gray",
+    icon: faChartBar,
+    title: "Sales",
+    value: "$103,430",
+    footer: {
+      color: "text-green-500",
+      value: "+5%",
+      label: "than yesterday",
+    },
+  },
+];
+
+export default statisticsCardsData;


### PR DESCRIPTION
This code organizes and exports data for statistics cards to be displayed in a dashboard. Each card represents a specific metric (e.g., revenue, users) with an icon, value, and trend analysis, making it easy to track key performance indicators in a visually appealing way